### PR TITLE
WIP: Manifest caching

### DIFF
--- a/Jakefile
+++ b/Jakefile
@@ -7,5 +7,5 @@ task('default', ['install-core'], function(params) {
 
 desc('install Lively Kernel core files from GitHub');
 task('install-core', [], function(params) {
-  exec('git clone git@github.com:rksm/LivelyKernel.git');
+  exec('git clone git@github.com:LivelyKernel/LivelyKernel.git');
 });

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -1,0 +1,90 @@
+/*global require, module*/
+
+// -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+// manifest files are used by web browsers for cacheing
+// -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+var exec = require('child_process').exec,
+    manifestFileName = "lively.scriptscache",
+    headers = {
+      'Content-Type': 'text/cache-manifest',
+      'Cache-Control': 'no-cache, private'
+    },
+    config;
+
+// -=-=-=-
+// helper
+// -=-=-=-
+function findJSFilesForManifest(rootDir, thenDo) {
+  // find all js files
+  // ignore .git and node_modules dirs
+  exec('find . \\( -name node_modules -or -name .git \\) -type d -prune -o -iname "*.js" -print',
+       {cwd: rootDir},
+       function(code, out, err) { thenDo(code, out); });
+}
+
+function buildManifestFileContents(thenDo) {
+  findJSFilesForManifest(config.fsNode, function(err, filesString) {
+    if (err) { thenDo(err); return; }
+    filesString = filesString.replace(/\.\//g, '/');
+    thenDo(null, "CACHE MANIFEST\n# version\n\n" + filesString);
+  });
+}
+
+// -=-=-=-=-=-
+// the handler
+// -=-=-=-=-=-
+function ManifestHandler(cfg) {
+  config = cfg;
+}
+
+ManifestHandler.prototype.registerWith = function(app) {
+  // route for serving the manifest file
+  if (!config.useManifestCaching) return;
+  app.get('/' + manifestFileName, function(req, res) {
+    buildManifestFileContents(function(err, contents) {
+      if (err) {
+        res.status(500).send('');
+      } else {
+        res.set(headers).send(contents);
+      }
+    });
+  });
+}
+
+ManifestHandler.prototype.addManifestRef = function(req, res) {
+  // when serving html files this methods rewrites what is send so that the
+  // html source includes a ref to the manifest file
+  if (!config.useManifestCaching) return;
+
+  // only when reading html files
+  if (!(/\.html$/.test(req.url)) || req.method.toLowerCase() !== 'get') return;
+
+  // that's a bit hacky....
+  var interceptedHeaders, interceptedHeadersCode,
+      writeFunc = res.write,
+      writeHeadFunc = res.writeHead;
+
+  res.writeHead = function(code, headers) {
+    interceptedHeaders = headers;
+    interceptedHeadersCode = code;
+    if (code >= 400) {
+      writeHeadFunc.call(this, code, headers);
+    }
+  }
+
+  res.write = function(data) {
+    if (interceptedHeadersCode >= 400) {
+      return writeFunc.call(this, data);
+    }
+    var s = data.toString();
+    s = s.replace(/<html>/, '<html manifest="' + manifestFileName + '">');
+    interceptedHeaders['content-length'] = s.length;
+    writeHeadFunc.call(this, interceptedHeadersCode, interceptedHeaders);
+    return writeFunc.call(this, s);
+  }
+}
+
+// -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+exports.ManifestHandler = ManifestHandler;

--- a/lib/subservers.js
+++ b/lib/subservers.js
@@ -4,16 +4,30 @@ var fs = require('fs'),
     path = require('path');
 
 var subserverDir = './../subservers/',
-    baseURL;
+    baseURL,
+    additionalSubservers;
 
 // -=-=-=-
 // helper
 // -=-=-=-
 
-function getSubserverModules() {
+function getFSSubserverModules() {
     return fs.readdirSync(path.join(__dirname, subserverDir))
            .filter(function(file) { return (/\.js$/.test(file)) })
-           .map(function(file) { return file.substr(0, file.lastIndexOf('.')); })
+           .map(function(file) {
+               var name = file.substr(0, file.lastIndexOf('.')),
+                   path = subserverDir + name,
+                   route = baseURL + name + '/';
+               return {name: name, path: path, route: route};
+           });
+}
+
+function getAdditionalSubservers() {
+    return Object.keys(additionalSubservers).map(function(name) {
+        var path = additionalSubservers[name],
+            route = baseURL + name + '/';
+        return {name: name, path: path, route: route};
+    });
 }
 
 // -=-=-=-=-=-=-
@@ -23,13 +37,13 @@ function getSubserverModules() {
 function SubserverHandler(config) {
     config = config || {};
     baseURL = config.baseURL || '/nodejs/';
+    additionalSubservers = config.additionalSubservers;
 }
 
 SubserverHandler.prototype.registerWith = function(app) {
-    getSubserverModules().forEach(function(serverName) {
-        var route = baseURL + serverName + '/';
-        console.log('starting subserver %s on route %s', serverName, route);
-        require(subserverDir + serverName)(route, app);
+    getFSSubserverModules().concat(getAdditionalSubservers()).forEach(function(serverSpec) {
+        console.log('starting subserver %s on route %s', serverSpec.name, serverSpec.route);
+        require(serverSpec.path)(serverSpec.route, app);
     })
 }
 

--- a/life_star.js
+++ b/life_star.js
@@ -26,6 +26,7 @@ module.exports = function serverSetup(config) {
   config.enableSSL           = config.enableSSL && config.sslServerKey && config.sslServerCert && config.sslCACert;
   config.enableSSLClientAuth = config.enableSSL && config.enableSSLClientAuth;
   config.behindProxy         = config.behindProxy || false;
+  config.subservers          = config.subservers || {};
 
   var app = express(), srv;
 
@@ -119,7 +120,7 @@ module.exports = function serverSetup(config) {
   // -=-=-=-=-=-=-=-
   // setup subserver
   // -=-=-=-=-=-=-=-
-  new SubserverHandler({baseURL: '/nodejs/'}).registerWith(app);
+  new SubserverHandler({baseURL: '/nodejs/', additionalSubservers: config.subservers}).registerWith(app);
 
   // -=-=-=-=-=-
   // set up DAV

--- a/life_star.js
+++ b/life_star.js
@@ -1,7 +1,7 @@
 /*global require, module*/
 var express = require('express'),
-    DavHandler = require('jsDAV/lib/DAV/handler').jsDAV_Handler,
-    FsTree = require('jsDAV/lib/DAV/tree/filesystem').jsDAV_Tree_Filesystem,
+    DavHandler = require('jsDAV/lib/DAV/handler'),
+    FsTree = require('jsDAV/lib/DAV/backends/fs/tree'),
     defaultPlugins = require("jsDAV/lib/DAV/server").DEFAULT_PLUGINS,
     log4js = require('log4js'),
     proxy = require('./lib/proxy'),
@@ -124,7 +124,7 @@ module.exports = function serverSetup(config) {
   // -=-=-=-=-=-
   // set up DAV
   // -=-=-=-=-=-
-  srv.tree = new FsTree(config.srvOptions.node);
+  srv.tree = FsTree.new(config.srvOptions.node);
   srv.tmpDir = './tmp'; // httpPut writes tmp files
   srv.options = {};
   // for showing dir contents

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "jsDAV": "https://github.com/mikedeboer/jsDAV/tarball/master",
     "express": "3.x",
     "log4js": "0.4.1",
-    "request": "2.1.1"
+    "request": "2.1.1",
+    "async": "0.1.22"
   },
   "devDependencies": {
     "nodeunit": ""

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "life_star",
-  "version": "0.1.2",
+  "version": "0.2.1",
   "author": "Fabian Bornhofen <fbornhofen@gmail.com>",
   "contributors": ["Robert Krahn <robert.krahn@gmail.com>"],
   "description": "Another web server for Lively",

--- a/standalone_star.js
+++ b/standalone_star.js
@@ -1,7 +1,7 @@
 require('./life_star')({
     host: 'localhost',
     port: 9001,
-    fsnode: '../LivelyKernel',
+    fsNode: '../LivelyKernel',
     enableTesting: true,
     logLevel: 'debug'
 });

--- a/tests/life_star-test.js
+++ b/tests/life_star-test.js
@@ -1,6 +1,7 @@
 /*global module, console, setTimeout*/
 
 var lifeStar = require("./../life_star"),
+    fs = require('fs'),
     server;
 
 function withLifeStarDo(test, func, options) {
@@ -25,7 +26,22 @@ function shutDownLifeStar(thenDo) {
     });
 }
 
+var tempFiles = [], tempDirs = [];
+function createTempFile(filename, content) {
+    fs.writeFileSync(filename, content);
+    tempFiles.push(filename);
+    console.log('created ' + filename);
+}
+
+function cleanupTempFiles() {
+    tempFiles.forEach(function(file) { fs.unlinkSync(file); });
+    tempFiles = [];
+}
+
+
 module.exports = {
     withLifeStarDo: withLifeStarDo,
-    shutDownLifeStar: shutDownLifeStar
+    shutDownLifeStar: shutDownLifeStar,
+    createTempFile: createTempFile,
+    cleanupTempFiles: cleanupTempFiles
 }

--- a/tests/life_star-test.js
+++ b/tests/life_star-test.js
@@ -3,9 +3,12 @@
 var lifeStar = require("./../life_star"),
     server;
 
-function withLifeStarDo(test, func) {
+function withLifeStarDo(test, func, options) {
     if (server) test.assert(false, 'life_star already running!')
-    server = lifeStar({host: 'localhost', port: 9999});
+    options = options || {};
+    options.host = options.host || 'localhost';
+    options.port = options.port || 9999;
+    server = lifeStar(options);
     server.on('error', function(e) {
         test.ifError(e);
         test.done();

--- a/tests/life_star-test.js
+++ b/tests/life_star-test.js
@@ -2,46 +2,93 @@
 
 var lifeStar = require("./../life_star"),
     fs = require('fs'),
+    exec = require('child_process').exec,
+    async = require('async'),
+    path = require('path'),
     server;
 
 function withLifeStarDo(test, func, options) {
-    if (server) test.assert(false, 'life_star already running!')
-    options = options || {};
-    options.host = options.host || 'localhost';
-    options.port = options.port || 9999;
-    server = lifeStar(options);
-    server.on('error', function(e) {
-        test.ifError(e);
-        test.done();
-    });
-    setTimeout(function() { func(server) }, 500);
+  if (server) test.assert(false, 'life_star already running!')
+  options = options || {};
+  options.host = options.host || 'localhost';
+  options.port = options.port || 9999;
+  server = lifeStar(options);
+  server.on('error', function(e) {
+    test.ifError(e);
+    test.done();
+  });
+  setTimeout(function() { func(server) }, 500);
 }
 
 function shutDownLifeStar(thenDo) {
-    if (!server) { thenDo(); return }
-    server.close(function() {
-        server = null;
-        console.log("life_star shutdown");
-        thenDo();
-    });
+  if (!server) { thenDo(); return }
+  server.close(function() {
+    server = null;
+    console.log("life_star shutdown");
+    thenDo();
+  });
 }
 
 var tempFiles = [], tempDirs = [];
 function createTempFile(filename, content) {
-    fs.writeFileSync(filename, content);
-    tempFiles.push(filename);
-    console.log('created ' + filename);
+  fs.writeFileSync(filename, content);
+  tempFiles.push(filename);
+  console.log('created ' + filename);
 }
 
-function cleanupTempFiles() {
-    tempFiles.forEach(function(file) { fs.unlinkSync(file); });
-    tempFiles = [];
+function createTempDir(dir) {
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir);
+  tempDirs.unshift(dir);
 }
 
+function cleanupTempFiles(thenDo) {
+  async.series(
+    tempFiles.map(function(file) {
+      return function(cb) { fs.unlinkSync(file); cb(); };
+    }).concat(tempDirs.map(function(dir) {
+      return function(cb) {
+        exec('rm -rfd ' + dir, function(code, out, err) { cb(); });
+      }
+    })),
+    function() {
+      tempFiles = [];
+      tempDirs = [];
+      thenDo && thenDo();
+    }
+  )
+}
+
+function createDirStructure(basePath, spec) {
+  // spec is an object like
+  // {"foo": {"bar.js": "bla"}}
+  // will create dir "foo/" and file foo/bar.js with "bla" as content
+  for (var name in spec) {
+    var p = path.join(basePath, name);
+    if (typeof spec[name] === 'string') {
+      createTempFile(p, spec[name]);
+      continue;
+    }
+    if (typeof spec[name] === 'object') {
+      createTempDir(p);
+      createDirStructure(p, spec[name]);
+      continue;
+    }
+  }
+}
+
+function withResponseBodyDo(res, callback) {
+  var data = "";
+  res.on('data', function(d) { data += d; })
+  res.on('end', function(err) {
+    callback(err, data);
+  });
+}
 
 module.exports = {
-    withLifeStarDo: withLifeStarDo,
-    shutDownLifeStar: shutDownLifeStar,
-    createTempFile: createTempFile,
-    cleanupTempFiles: cleanupTempFiles
+  withLifeStarDo: withLifeStarDo,
+  shutDownLifeStar: shutDownLifeStar,
+  createTempFile: createTempFile,
+  cleanupTempFiles: cleanupTempFiles,
+  createDirStructure: createDirStructure,
+  withResponseBodyDo: withResponseBodyDo
 }

--- a/tests/manifest-test.js
+++ b/tests/manifest-test.js
@@ -1,0 +1,75 @@
+/*global exports, require, JSON, __dirname, console*/
+
+// continously run with:
+// nodemon nodeunit tests/manifest-test.js
+
+var testHelper = require('./test-helper'),
+    http = require('http'),
+    lifeStarTest = require("./life_star-test"),
+    testSuite = {},
+    fs = require('fs');
+
+function createSimpleHTML() {
+  var source = "<!DOCTYPE html>\n"
+             + "<html>\n"
+             + "  <head><title>Foo</title></head>\n"
+             + "  <body>Test</body>\n"
+             + "</html>\n"
+             + "\n";
+  lifeStarTest.createTempFile(__dirname + '/simple.html', source);
+}
+
+testSuite.SubserverTest = {
+
+  setUp: function(run) {
+    run();
+  },
+
+  tearDown: function(run) {
+    lifeStarTest.cleanupTempFiles();
+    lifeStarTest.shutDownLifeStar(run);
+  },
+
+  "life star is embedding manifest ref in html": function(test) {
+    createSimpleHTML();
+    lifeStarTest.withLifeStarDo(test, function() {
+      http.get('http://localhost:9999/simple.html', function(res) {
+        test.equals(200, res.statusCode);
+        var data = "";
+        res.on('data', function(d) { data += d; })
+        res.on('end', function(err) {
+          test.ok(/<html manifest="lively.scriptscache">/.test(data),
+                  'No manifest ref in ' + data);
+          test.done();
+        });
+      });
+    }, {fsNode: __dirname + '/'});
+  },
+
+  "life star is not embedding manifest ref if feature is disabled": function(test) {
+    createSimpleHTML();
+    lifeStarTest.withLifeStarDo(test, function() {
+      http.get('http://localhost:9999/simple.html', function(res) {
+        test.equals(200, res.statusCode);
+        var data = "";
+        res.on('data', function(d) { data += d; })
+        res.on('end', function(err) {
+          test.ok(/<html>/.test(data), 'Manifest unexpectedly in ' + data);
+          test.done();
+        });
+      });
+    }, {fsNode: __dirname + '/', useManifestCaching: false});
+  },
+
+  "don't crash on requests of non-existing files": function(test) {
+    lifeStarTest.withLifeStarDo(test, function() {
+      http.get('http://localhost:9999/does-not-exist.html', function(res) {
+        test.equals(404, res.statusCode);
+        test.done();
+      });
+    }, {fsNode: __dirname + '/'})
+  }
+
+}
+
+exports.testSuite = testSuite;

--- a/tests/subservers-test.js
+++ b/tests/subservers-test.js
@@ -25,8 +25,9 @@ testSuite.SubserverTest = {
     },
 
     tearDown: function(run) {
-        lifeStarTest.cleanupTempFiles();
+      lifeStarTest.cleanupTempFiles(function() {
         lifeStarTest.shutDownLifeStar(run);
+      });
     },
 
     "life star is running": function(test) {

--- a/tests/subservers-test.js
+++ b/tests/subservers-test.js
@@ -1,7 +1,7 @@
 /*global exports, require, JSON, __dirname, console*/
 
 // continously run with:
-// nodemon nodeunit tests/workspace-test.js
+// nodemon nodeunit tests/subservers-test.js
 
 var testHelper = require('./test-helper'),
     http = require('http'),
@@ -21,6 +21,15 @@ function cleanupTempFiles() {
         fs.unlinkSync(file);
     });
     tempFiles = [];
+}
+
+function createSubserverFile(path) {
+    var simpleServerSource = "module.exports = function(baseRoute, app) {\n"
+                           + "    app.get(baseRoute, function(req, res) {\n"
+                           + "        res.send('hello');\n"
+                           + "    });\n"
+                           + "}\n";
+    createTempFile(path, simpleServerSource);
 }
 
 testSuite.SubserverTest = {
@@ -44,12 +53,7 @@ testSuite.SubserverTest = {
     },
 
     "server placed in subserver dir is started and accessible": function(test) {
-        var simpleServerSource = "module.exports = function(baseRoute, app) {\n"
-                               + "    app.get(baseRoute, function(req, res) {\n"
-                               + "        res.send('hello');\n"
-                               + "    });\n"
-                               + "}\n";
-        createTempFile(__dirname + '/../subservers/foo.js', simpleServerSource);
+        createSubserverFile(__dirname + '/../subservers/foo.js');
         lifeStarTest.withLifeStarDo(test, function() {
             http.get('http://localhost:9999/nodejs/foo/', function(res) {
                 var data = "";
@@ -61,6 +65,20 @@ testSuite.SubserverTest = {
                 })
             });
         })
+    },
+
+    "subservers via options are started": function(test) {
+        createSubserverFile(__dirname + '/foo.js');
+        lifeStarTest.withLifeStarDo(test, function() {
+            http.get('http://localhost:9999/nodejs/bar/', function(res) {
+                var data = "";
+                res.on('data', function(d) { data += d; })
+                res.on('end', function(err) {
+                    test.equals('hello', data);
+                    test.done();
+                })
+            });
+        }, {subservers: {bar: __dirname + '/foo.js'}});
     }
 
 }

--- a/tests/subservers-test.js
+++ b/tests/subservers-test.js
@@ -9,27 +9,13 @@ var testHelper = require('./test-helper'),
     testSuite = {},
     fs = require('fs');
 
-var tempFiles = [], tempDirs = [];
-function createTempFile(filename, content) {
-    fs.writeFileSync(filename, content);
-    tempFiles.push(filename);
-    console.log('created ' + filename);
-}
-
-function cleanupTempFiles() {
-    tempFiles.forEach(function(file) {
-        fs.unlinkSync(file);
-    });
-    tempFiles = [];
-}
-
 function createSubserverFile(path) {
     var simpleServerSource = "module.exports = function(baseRoute, app) {\n"
                            + "    app.get(baseRoute, function(req, res) {\n"
                            + "        res.send('hello');\n"
                            + "    });\n"
                            + "}\n";
-    createTempFile(path, simpleServerSource);
+    lifeStarTest.createTempFile(path, simpleServerSource);
 }
 
 testSuite.SubserverTest = {
@@ -39,7 +25,7 @@ testSuite.SubserverTest = {
     },
 
     tearDown: function(run) {
-        cleanupTempFiles();
+        lifeStarTest.cleanupTempFiles();
         lifeStarTest.shutDownLifeStar(run);
     },
 


### PR DESCRIPTION
This implements support for HTML5 caching that uses a page specific manifest file to control which sources should be cached by the browser.

We need this especially for iPad support since the native caching of mobile webkit isn't usable for "larger" (> 15kb) files. This also should render the combinedModules approach on webwerkstatt unnecessary.

See http://www.html5rocks.com/en/tutorials/appcache/beginner/ for more infos.
